### PR TITLE
fix: Harden init and window spawn to avoid hangs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .luarc.json
 kitty/socket
+kitty/kitty_daemon.out
+kitty/kitty_daemon.err

--- a/kitty/init.lua
+++ b/kitty/init.lua
@@ -1,65 +1,87 @@
-local kittyDir = hs.spoons.scriptPath()
+local kittyVisorDir = hs.spoons.scriptPath()
 
 local kitty = {
-  socket = kittyDir .. "socket",
+  socket = kittyVisorDir .. "socket",
+  daemon_stdout = kittyVisorDir .. "kitty_daemon.out",
+  daemon_stderr = kittyVisorDir .. "kitty_daemon.err",
 }
 
-local function _getVisorWindow(self)
-  local visorWindow = nil
-  for _, termApp in pairs(hs.application.applicationsForBundleID(self.bundleId)) do
-    visorWindow = termApp and termApp:getWindow(self.windowIdentifier)
-    if visorWindow then
-      log.v("Found visor window. App name:" .. termApp:name() .. ", bundleId: " .. termApp:bundleID())
-      break
-    end
+local function _cleanup_logs()
+  local ret_code, delete_err = os.remove(kitty.daemon_stdout)
+  if not ret_code then
+    log.w("Couldn't clean up daemon output logs, reason: " .. tostring(delete_err))
   end
-
-  return visorWindow
-end
-
-local function _kitty_ls(self)
-  return hs.execute(string.format([[%s @ --to unix:%s ls]], self.opts.kitten, self.socket))
-end
-
-local function _spawn_kitty_daemon_cmd(self)
-  local kittyCmd = ((self.launchCmdLine.nohup and "nohup ") or "") .. self.launchCmdLine.executable
-  for _, v in ipairs(self.launchCmdLine.args) do
-    kittyCmd = kittyCmd .. " " .. tostring(v)
-  end
-  if self.launchCmdLine.background then
-    kittyCmd = kittyCmd .. " &"
-  end
-
-  return kittyCmd
-end
-
-local function _create_visor_window_cmd(self)
-  return string.format([[%s @ --to unix:%s launch --dont-take-focus]], self.opts.kitten, self.socket)
-end
-
-local function _cleanup_socket(self)
-  log.v("Cleaning up stale Unix sockets")
-  local cleanupSocket = string.format(
-    [[rm -rf %s 2>&1]],
-    self.socket
-  )
-  local out, success, exit_type, ret_code = hs.execute(cleanupSocket)
-  if not success then
-    log.w(string.format(
-      [[
-            Problem cleaning up old Unix socket: %s %s
-            output: %s
-          ]], exit_type, ret_code, out
-    ))
+  ret_code, delete_err = os.remove(kitty.daemon_stderr)
+  if not ret_code then
+    log.w("Couldn't clean up daemon error logs, reason: " .. tostring(delete_err))
   end
 end
 
 local function _get_daemon_pid(self)
-    -- We don't error on status here because an error
+  -- We don't error on status here because an error
   -- indicates a failure to lookup the PID which is part of
   -- what we're trying to figure out (does the PID exist)
-  local pid, status = hs.execute(string.format([[pgrep -f %s 2>&1]], self.windowIdentifier))
+  local pid, status = hs.execute(string.format([[pgrep -f -n %s 2>&1]], self.windowIdentifier))
+  log.df("status: %s, pid: %s", tostring(status), tostring(pid))
   return (status and pid) or nil
+end
+
+local function _getVisorWindow(self, kitty_pid)
+  local visorWindow = nil
+  local pid = kitty_pid or _get_daemon_pid(self)
+  local termApp = (pid and hs.application.applicationForPID(tonumber(pid))) or nil
+  if termApp then
+    log.df("Term app found: %s", hs.inspect(termApp))
+    visorWindow = termApp and termApp:getWindow(self.windowIdentifier)
+    if visorWindow then
+      log.d("Found visor window. App name:" .. termApp:name() .. ", bundleId: " .. termApp:bundleID())
+    end
+  else
+    log.w("No Kitty app instance while trying to find existing visor window.")
+  end
+  return visorWindow
+end
+
+local function _kitty_ls(self)
+  return hs.execute(string.format([[%s @ --to unix:%s ls 2>&1]], self.opts.kitten, self.socket))
+end
+
+local function _spawn_kitty_daemon_cmd(self)
+  local kittyCmd = self.launchCmdLine.executable
+  for _, v in ipairs(self.launchCmdLine.args) do
+    kittyCmd = kittyCmd .. " " .. tostring(v)
+  end
+  return string.format(
+    "%s%s%s%s",
+    (self.launchCmdLine.background and string.format("1>%s 2>%s ", kitty.daemon_stdout, kitty.daemon_stderr)) or "",
+    (self.launchCmdLine.nohup and "nohup ") or "",
+    kittyCmd,
+    (self.launchCmdLine.background and " &") or ""
+  )
+end
+
+local function _create_visor_window_cmd(self)
+  return string.format(
+    [[%s @ --to unix:%s launch --dont-take-focus --no-response 2>&1]],
+    self.opts.kitten,
+    self.socket,
+    self.windowIdentifier,
+    self.daemon_stdout,
+    self.daemon_stderr
+  )
+end
+
+local function _cleanup_socket(self)
+  local test, err, code = os.rename(self.socket, self.socket)
+  if not test then
+    if code ~= 13 then
+      return true
+    else
+      return test, err, code
+    end
+  end
+  log.d("Cleaning up stale Unix sockets")
+  return os.remove(self.socket)
 end
 
 local function _get_opacity(self)
@@ -76,7 +98,8 @@ local function _get_opacity(self)
 
   local kitty_json, status, err_type, ret_code = _kitty_ls(self)
   if not status then
-    error(string.format("Error querying kitty window details: %s %s", err_type, ret_code))
+    log.ef("Error querying kitty window details: %s %s %s ", err_type, ret_code, kitty_json)
+    return nil
   end
 
   return hs.json.decode(kitty_json)[1].background_opacity
@@ -103,22 +126,87 @@ local function _set_opacity(self)
   end
 end
 
-function kitty:startVisorWindow(display)
-  local pid = _get_daemon_pid(self)
-  local kittyCmd = (pid and _create_visor_window_cmd(self)) or _spawn_kitty_daemon_cmd(self)
-  log.v("Starting kitty window with command" .. kittyCmd)
+local function _launch_visor_window(self)
+  local out, status, err_type, ret_code = hs.execute(_create_visor_window_cmd(self))
+  if not status then
+    log.wf("Error creating visor window: %s %s %s", err_type, ret_code, out)
+  end
+end
 
+local function _do_spawn(self)
+  local pid = _get_daemon_pid(self)
+  local kittyCmd = (pid and _create_visor_window_cmd(self)) or (_cleanup_socket(self) and _spawn_kitty_daemon_cmd(self))
+  if not kittyCmd then
+    log.ef("Couldn't construct kitty start command from %s", hs.inspect(self.launchCmdLine))
+    return nil
+  end
+  if pid then
+    log.d("Creating Visor window for kitty daemon")
+  else
+    log.d("Spawning kitty daemon")
+  end
+  -- If we background the terminal this should always be true so we're
+  -- going to need an additional check to make sure the command spawned
+  -- correctly later.
+  log.df("Executing kitty cmd %q", kittyCmd)
   local status, err_type, ret_code = os.execute(kittyCmd)
   if not status then
-    error(string.format("Error creating visor window: %s %s", err_type, ret_code), 2)
+    log.ef("Error creating visor window: %s %s", err_type, ret_code)
   end
 
+  if pid then return pid end
+
+  -- Did a fresh spawn, so update the PID. We need to check this again
+  -- before we try to poll for a window.
+  pid = _get_daemon_pid(self)
+  if not pid then
+    -- files used by background spawn command
+    local stdout, out_open_err = io.open(kitty.daemon_stdout, "r")
+    local stderr, err_open_err = io.open(kitty.daemon_stderr, "r")
+
+    if stdout then stdout:flush() end
+    if stderr then stderr:flush() end
+
+    local output_string = stdout and stdout:read("*a") or
+      ("Error opening file: " .. tostring(out_open_err or "Unknown Error"))
+    local err_string = stderr and stderr:read("*a") or
+      ("Error opening file: " .. tostring(err_open_err or "Unknown Error"))
+
+    log.ef(
+      [[
+      Could not locate PID of Kitty daemon; checking output files.
+      stdout: %s
+      stderr: %s
+    ]], output_string, err_string)
+
+    if stdout then stdout:close() end
+    if stderr then stderr:close() end
+  end
+
+  return pid
+end
+
+function kitty:startVisorWindow(display)
   local visorWindow = nil
+  local pid = _do_spawn(self)
+
+  if not pid then
+    log.e("Couldn't start Kitty daemon, can't start and show Visor window.")
+    return
+  end
+
   repeat
-    visorWindow = _getVisorWindow(self)
+    log.df("Passing PID to visor window: %s", pid)
+    visorWindow = _getVisorWindow(self, pid)
+    if not visorWindow then _launch_visor_window(self) end
   until visorWindow ~= nil
 
-  local appPID = pid or visorWindow:application():pid()
+  kitty.currentOpacity = _get_opacity(self)
+
+  local appPID = pid or (visorWindow and visorWindow:application():pid()) or nil
+  if not appPID then
+    error("Failed to get kitty app PID for attaching watcher")
+  end
   hs.application.watcher.new(function(app_name, event_type, app)
     if app:pid() == appPID and event_type == hs.application.watcher.terminated then
       _cleanup_socket(self)
@@ -134,18 +222,20 @@ function kitty:hideVisorWindow(visorWindow)
 end
 
 function kitty:showVisorWindow(visorWindow, display)
+  local screenFrame = display:fullFrame()
+  visorWindow:move(
+    hs.geometry {
+      x = screenFrame.x,
+      y = screenFrame.y,
+      w = screenFrame.w,
+      h = screenFrame.h *
+        self.opts.height
+    },
+    0
+  )
   if self.opts.opacity ~= self.currentOpacity then
     _set_opacity(self)
   end
-  local screenFrame = display:fullFrame()
-  local windowFrame = visorWindow:frame()
-  windowFrame.w = screenFrame.w
-  windowFrame.h = screenFrame.h * self.opts.height
-  windowFrame.y = screenFrame.y
-  windowFrame.x = screenFrame.x
-  visorWindow:setFrame(windowFrame, 0)
-  visorWindow:move(hs.geometry({ x = 0, y = 0 }))
-  visorWindow:unminimize()
   visorWindow:application():unhide()
   visorWindow:focus()
   return visorWindow
@@ -158,9 +248,11 @@ function kitty:getTerminalAppAndVisor(maybeVisorWindow)
 end
 
 function kitty:init()
+  _cleanup_logs()
   local pid = _get_daemon_pid(self)
+  log.df("PID in kitty:init(): %s", tostring(pid))
   if not pid then
-    _cleanup_socket(self)
+    _do_spawn(self)
     return
   end
 

--- a/kitty/visor_window.conf
+++ b/kitty/visor_window.conf
@@ -1,8 +1,12 @@
-dynamic_background_opacity yes
-hide_window_decorations titlebar-and-corners
+allow_remote_control yes
+background_opacity 0
 confirm_os_window_close 0
-remember_window_size yes
+dynamic_background_opacity yes
+hide_window_decorations yes
 macos_hide_from_tasks yes
+macos_quit_when_last_window_closed no
+macos_traditional_fullscreen yes
+remember_window_size yes
 
 map cmd+n launch open -a kitty.app -n
 map ctrl+shift+n launch open -a kitty.app -n


### PR DESCRIPTION
There were both a handful of bugs in the Spoon and in Hammerspooon as
well that would sometimes cause the Spoon to hang on launch.

This refactors the initialization and launch setup to avoid these hangs.

Resolves: #1 